### PR TITLE
Fix version file URL property

### DIFF
--- a/RealHeat/RealHeat.version
+++ b/RealHeat/RealHeat.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Real Heat",
-  "URL": "https://forum.kerbalspaceprogram.com/index.php?/topic/115066-113-realheat-minimalist-v43-july-3/",
+  "URL": "https://github.com/KSP-RO/RealHeat/raw/master/RealHeat/RealHeat.version",
   "DOWNLOAD": "https://github.com/KSP-RO/RealHeat/releases",
   "GITHUB": {
     "USERNAME": "KSP-RO",


### PR DESCRIPTION
The URL property is supposed to point to an online copy of the version file that can be checked for updates, but currently it's the forum thread.
Now it's fixed.